### PR TITLE
qviart-opengl-hisi3798mv200: restrict it to COMPATIBLE_MACHINE

### DIFF
--- a/recipes-graphics/qviart-opengl-hisi3798mv200.bb
+++ b/recipes-graphics/qviart-opengl-hisi3798mv200.bb
@@ -4,3 +4,5 @@ SRC_URI[md5sum] = "796497b786062ff2641285eaf4717d0b"
 SRC_URI[sha256sum] = "95f4ecd9c90f07075dd24493baa4a440d6140007d33e9238fc37de111ae2c574"
 
 require qviart-opengl.inc
+
+COMPATIBLE_MACHINE = "^(lunix4k)$"


### PR DESCRIPTION
The driver otherwise slips in other builds as virtual/egl provider:

 v3d-libgles-72604 PROVIDES virtual/egl but was skipped:
 PREFERRED_PROVIDER_virtual/libgles2 set to zgemma-v3ddriver-i55,
 not v3d-libgles-72604

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>