### PR TITLE
lunix4k.conf: rename v3d -> nextv-cortexa15

### DIFF
--- a/conf/machine/lunix4k.conf
+++ b/conf/machine/lunix4k.conf
@@ -9,7 +9,7 @@ UPDATE_DIR = "lunix4k"
 
 require conf/machine/include/qviart4k.inc
 
-MACHINE_FEATURES += "blindscan-dvbs proxy v3d swap dvb-c textlcd"
+MACHINE_FEATURES += "blindscan-dvbs proxy nextv-cortexa15 swap dvb-c textlcd"
 OPENPLI_FEATURES += "kodi"
 
 KV = "linux-4.1.20"
@@ -29,11 +29,9 @@ PREFERRED_PROVIDER_virtual/egl = "v3d-libgles-${CHIP}"
 PREFERRED_PROVIDER_virtual/libgles2 = "v3d-libgles-${CHIP}"
 PREFERRED_PROVIDER_virtual/blindscan-dvbs = "qviart-blindscan-utils-${CHIP}"
 
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
-
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += " \
 	${@bb.utils.contains("MACHINE_FEATURES", "proxy", "platform-util-${CHIP} qviart-dvb-modules-proxy${CHIP}", "", d)} \
-	${@bb.utils.contains("MACHINE_FEATURES", "v3d", "v3d-libgles-${CHIP}","", d)} \
+	${@bb.utils.contains("MACHINE_FEATURES", "nextv-cortexa15", "v3d-libgles-${CHIP}","", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "swap", "swapcreate-${CHIP}", "", d)} \
 	${@bb.utils.contains("MACHINE_FEATURES", "blindscan-dvbs", "qviart-blindscan-utils-${CHIP}", "", d)} \
 "


### PR DESCRIPTION
for kodi, use the same naming as in OE-A and OpenPLi

 while there remove EXTRA_OECONF_append_pn-kodi
 in kodi > 18 this is now unnecessary in the machine conf files,
 it is derived from MACHINE_FEATURES

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>